### PR TITLE
:bug: Switch from double to decimal type

### DIFF
--- a/src/Solana.Unity.Dex/Math/DecimalUtil.cs
+++ b/src/Solana.Unity.Dex/Math/DecimalUtil.cs
@@ -4,23 +4,28 @@ namespace Solana.Unity.Dex.Math;
 
 public class DecimalUtil
 {
-    public static double FromUlong(ulong value, int shift = 0)
+    public static decimal FromUlong(ulong value, int shift = 0)
     {
-        return value / System.Math.Pow(10, shift);
+        return value / (decimal)System.Math.Pow(10, shift);
     }
     
-    public static double FromBigInteger(BigInteger value, int shift = 0)
+    public static decimal FromBigInteger(BigInteger value, int shift = 0)
     {
         return FromUlong((ulong)value, shift);
     }
     
     public static ulong ToUlong(double value, int shift = 0)
     {
-        return (ulong)(value * System.Math.Pow(10, shift));
+        return ToUlong((decimal)value, shift);
     }
     
     public static ulong ToUlong(float value, int shift = 0)
     {
-        return ToUlong((double)value, shift);
+        return ToUlong((decimal)value, shift);
+    }
+    
+    public static ulong ToUlong(decimal value, int shift = 0)
+    {
+        return (ulong)(value * (decimal)System.Math.Pow(10, shift));;
     }
 }

--- a/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/DecimalsUtilsTests.cs
+++ b/test/Solana.Unity.Dex.Test/Orca/SdkTests/UtilsTests/DecimalsUtilsTests.cs
@@ -14,13 +14,13 @@ namespace Solana.Unity.Dex.Test.Orca.SdkTests.UtilsTests
             {
                 ulong value = 100_000_000;
                 int decimals = 6;
-                var valueDouble = DecimalUtil.FromUlong(value, decimals);
-                Assert.IsTrue(valueDouble.Equals(100.0));
+                var valueDecimals = DecimalUtil.FromUlong(value, decimals);
+                Assert.IsTrue(valueDecimals.Equals((decimal)100.0));
                 
-                Assert.IsTrue(DecimalUtil.ToUlong(valueDouble, decimals).Equals(value));
-                Assert.IsTrue(DecimalUtil.ToUlong((float)valueDouble, decimals).Equals(value));
+                Assert.IsTrue(DecimalUtil.ToUlong(valueDecimals, decimals).Equals(value));
+                Assert.IsTrue(DecimalUtil.ToUlong((float)valueDecimals, decimals).Equals(value));
 
-                Assert.IsTrue(DecimalUtil.FromBigInteger(value, decimals).Equals(valueDouble));
+                Assert.IsTrue(DecimalUtil.FromBigInteger(value, decimals).Equals(valueDecimals));
             }
             
         }


### PR DESCRIPTION
Switch from double to decimal type to handle edge cases


| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | - |

## Problem

Some conversion with very low or high number was returning 0


## Solution

Use decimals type instead of double in the Math utils