### PR TITLE
:bug: Fix unity code stripping for KeyStore

### DIFF
--- a/src/Solana.Unity.KeyStore/Resources/link.xml
+++ b/src/Solana.Unity.KeyStore/Resources/link.xml
@@ -1,0 +1,10 @@
+<linker>
+  
+  <!--Preserve Solana.Unity.KeyStore assembly-->
+  
+  <assembly fullname="Solana.Unity.KeyStore">
+    <namespace fullname="Solana.Unity.KeyStore" preserve="all"/>
+    <type fullname="Solana.Unity.KeyStore.*" preserve="all"/>
+  </assembly>
+
+</linker>

--- a/src/Solana.Unity.KeyStore/Solana.Unity.KeyStore.csproj
+++ b/src/Solana.Unity.KeyStore/Solana.Unity.KeyStore.csproj
@@ -17,5 +17,11 @@
     <ProjectReference Include="..\Solana.Unity.Wallet\Solana.Unity.Wallet.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Solana.Unity.KeyStore.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <Import Project="..\..\SharedBuildProperties.props" />
 </Project>


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Bug/Hotfix | Yes| - |

## Problem

_In Game Wallet Login not working in WebGL_

## Solution

_Prevent Unity to strip code from KeyStore. EncryptedKeystoreJson was invalid and that made login fail_


## Before & After Screenshots

**BEFORE**:
<img width="384" alt="image" src="https://github.com/magicblock-labs/Solana.Unity-Core/assets/27894772/6c55fc79-f2a0-4faa-b8cd-39d4106a5e28">

## Deploy Notes
_Need to build .dll and publish to Solana.Unity-SDK_